### PR TITLE
Autoload for all ac-XXX-enable and vars ac-source-html-XXX for web-mode

### DIFF
--- a/ac-haml.el
+++ b/ac-haml.el
@@ -88,6 +88,7 @@
     (document . ac-source-haml-attribute-value-document)
     ))
 
+;;;###autoload
 (defun ac-haml-enable ()
   "Add ac-haml sources into ac-sources and enable auto-comple-mode"
   (interactive)

--- a/ac-html.el
+++ b/ac-html.el
@@ -286,18 +286,21 @@ Those files may have documantation delimited by \" \" symbol."
   (if (re-search-backward "\\w=[\"]\\([^\"]+[ ]\\|\\)\\(.*\\)" nil t)
       (match-beginning 2)))
 
+;;;###autoload
 (defvar ac-source-html-tag
   '((candidates . ac-source-html-tag-candidates)
     (prefix . "<\\(.*\\)")
     (symbol . "t")
     (document . ac-source--html-tag-documentation)))
 
+;;;###autoload
 (defvar ac-source-html-attribute
   '((candidates . ac-source-html-attribute-candidates)
     (prefix . "<\\w[^>]*[[:space:]]+\\(.*\\)")
     (symbol . "a")
     (document . ac-source-html-attribute-documentation)))
 
+;;;###autoload
 (defvar ac-source-html-attribute-value
   '((candidates . ac-source-html-attribute-value-candidates)
     (prefix . ac-html-value-prefix)

--- a/ac-jade.el
+++ b/ac-jade.el
@@ -88,6 +88,7 @@
     (document . ac-source-jade-attribute-value-document)
     ))
 
+;;;###autoload
 (defun ac-jade-enable ()
   "Add ac-jade sources into ac-sources and enable auto-comple-mode"
   (interactive)

--- a/ac-slim.el
+++ b/ac-slim.el
@@ -88,6 +88,7 @@
     (document . ac-source-slim-attribute-value-document)
     ))
 
+;;;###autoload
 (defun ac-slim-enable ()
   "Add ac-slim sources into ac-sources and enable auto-comple-mode"
   (interactive)


### PR DESCRIPTION
I think better have autoload for vars ac-source-html-XXX that may be used in web mode and other enable func of jade, etc
