### PR TITLE
Fix recursion of ac-html--flatten, used -flatten from dash instead

### DIFF
--- a/Cask
+++ b/Cask
@@ -2,6 +2,7 @@
 (source melpa)
 
 (depends-on "auto-complete")
+(depends-on "dash")
 (depends-on "web-completion-data")
 
 (development

--- a/ac-html.el
+++ b/ac-html.el
@@ -3,9 +3,9 @@
 ;; Copyright (C) 2014 Zhang Kai Yu
 
 ;; Author: Zhang Kai Yu <yeannylam@gmail.com>
-;; Version: 0.31
+;; Version: 0.32
 ;; Keywords: html, auto-complete, rails, ruby
-;; Package-Requires: ((auto-complete "1.4") (web-completion-data "0.1"))
+;; Package-Requires: ((auto-complete "1.4") (dash "2.8.0") (web-completion-data "0.1"))
 ;; URL: https://github.com/cheunghy/ac-html
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -46,6 +46,7 @@
 (require 'auto-complete)
 (require 'auto-complete-config)
 (require 'cl)
+(require 'dash)
 (require 'web-completion-data)
 
 ;;; Customization
@@ -139,13 +140,6 @@ Returns an alist. car is source name, cdr is the file path."
           web-completion-data-sources)
     return-files))
 
-(defun ac-html--flatten (wtf)
-  "Flatten WTF, into a list."
-  (cond ((null wtf) nil)
-        ((atom wtf) (list wtf))
-        (t (append (ac-html--flatten (car wtf))
-                   (ac-html--flatten (cdr wtf))))))
-
 (defun ac-html--make-popup-items (summary items documentation)
   "Make popup-item for each item with SUMMARY.
 
@@ -182,7 +176,7 @@ DOCUMENTATION is string or function."
         (buffer-string)))))
 
 (defun ac-html--tags ()
-  (ac-html--flatten
+  (-flatten
    (mapcar (lambda (source-name-and-file-path)
              (ac-html--make-popup-items
               (car source-name-and-file-path)
@@ -237,7 +231,7 @@ DOCUMENTATION is string or function."
                               ))
                            (ac-html--all-files-named
                             (concat "html-attributes-list/" tag-string))))
-      (ac-html--flatten items))))
+      (-flatten items))))
 
 (defun ac-source--html-values-internal (tag-string attribute-string)
   "Read html-stuff/html-attributes-complete/global-<ATTRIBUTE>
@@ -263,7 +257,7 @@ Those files may have documantation delimited by \" \" symbol."
                          (ac-html--all-files-named
                           (format "html-attributes-complete/%s-%s" tag-string
                                   attribute-string))))
-    (ac-html--flatten items)))
+    (-flatten items)))
 
 (defun ac-source--html-attribute-values (tag-string attribute-string)
   (if (and ac-html-complete-css

--- a/test/ac-html-test.el
+++ b/test/ac-html-test.el
@@ -2,17 +2,18 @@
 
 ;;; Core test
 
+;; test dash -flatten
 (ert-deftest test-ac-html--flatten-returns-nil ()
-  "`ac-html--flatten' should return nil when argument is nil."
-  (should (null (ac-html--flatten nil))))
+  "`-flatten' should return nil when argument is nil."
+  (should (null (-flatten nil))))
 
 (ert-deftest test-ac-html--flatten-returns-list ()
-  "`ac-html--flatten' should return list of argument when argument is atom."
-  (should (equal (ac-html--flatten "wtf") '("wtf"))))
+  "`-flatten' should return list of argument when argument is atom."
+  (should (equal (-flatten "wtf") '("wtf"))))
 
 (ert-deftest test-ac-html--flatten-returns-flatten-list ()
-  "`ac-html--flatten' should return list of argument when argument is atom."
-  (should (equal (ac-html--flatten
+  "`-flatten' should return list of argument when argument is atom."
+  (should (equal (-flatten
                   '(1 2 (3 (((4))) 5 ((6)) 7) 8)) '(1 2 3 4 5 6 7 8))))
 
 (setq web-completion-data-sources (list (cons "html01" (expand-file-name "fixtures/01" ac-html-test-dir))


### PR DESCRIPTION
Hello again,

I found why I get strange behavior on my ac-html-bootstrap package, on large completion list, function `ac-html--flatten` have fall in deep recursion and stop completion:
```
ac-html--flatten: Lisp nesting exceeds `max-lisp-eval-depth' [2 times]
```

I replace it with `-flatten` from dash package, which is like underscore.js but for lisp, very usefull package :), I found here good programming patterns for lisp
