### PR TITLE
Fix library loading for byte-compile warnings

### DIFF
--- a/ac-html-core.el
+++ b/ac-html-core.el
@@ -25,6 +25,7 @@
 
 (require 'auto-complete)
 (require 'cl-lib)
+(require 'dash)
 
 ;;; Customization
 

--- a/ac-slim.el
+++ b/ac-slim.el
@@ -27,7 +27,7 @@
 
 (require 'ac-html-core)
 
-(require 'dash)
+(require 's)
 
 (defun ac-slim-inside-ruby-code ()
   "Return t if inside ruby code."


### PR DESCRIPTION
There are two byte-compile warning in original code.

```
ac-html-core.el:263:1:Warning: the function `-concat' is not known to be
    defined.

ac-slim.el:155:1:Warning: the following functions are not known to be defined: s-matches-p,
    s-match
```
